### PR TITLE
feature/fix-1

### DIFF
--- a/Travel.Api/DTOs/TripProfile.cs
+++ b/Travel.Api/DTOs/TripProfile.cs
@@ -1,14 +1,18 @@
 using AutoMapper;
-using Travel.Model;
+using Travel.Domain.Entities;
+using Travel.Model.Trip;
+using Travel.Model.TripImage;
 
 namespace Travel.Api.DTOs;
 public class TripProfile : Profile
 {
     public TripProfile()
     {
-        CreateMap<CreateTripDto, Trip>();
-        CreateMap<CreateTripImageDto, TripImage>();
-        CreateMap<PatchTripDto, Trip>()
+        CreateMap<TripEntity, Trip>();
+        CreateMap<TripImageEntity, TripImage>();
+        CreateMap<TripCreated, TripEntity>();
+        CreateMap<TripImageCreated, TripImageEntity>();
+        CreateMap<TripUpdated, TripEntity>()
             .ForAllMembers(opt => opt.Condition((src, dest, srcMember) =>
             {
                 // Skip nulls
@@ -21,7 +25,7 @@ public class TripProfile : Profile
                 return true;
             }));
         
-        CreateMap<PatchTripImageDto, TripImage>()
+        CreateMap<TripImageUpdated, TripImageEntity>()
             .ForAllMembers(opt =>
                 opt.Condition((src, dest, srcMember, destMember, context) =>
                 {

--- a/Travel.Api/Endpoints/ImageHandlers.cs
+++ b/Travel.Api/Endpoints/ImageHandlers.cs
@@ -2,32 +2,32 @@ using AutoMapper;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Minio.DataModel.Response;
-using Travel.Api.DTOs;
 using Travel.Application.Interfaces;
-using Travel.Model;
+using Travel.Domain.Entities;
+using Travel.Model.TripImage;
 
 
 namespace Travel.Api.Endpoints;
 
 internal static class ImageHandlers
 {
-    private static List<TripImage> _tripImages =
+    private static List<TripImageEntity> _tripImages =
     [
-        new TripImage
+        new TripImageEntity
         {
             Id = Guid.Parse("10AAC809-C188-458D-A12E-1AFC92E2FEE3"),
             Url = "http://google.com/myimage.png",
             Caption = "This is my image",
             TripId = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F")
         },
-        new TripImage
+        new TripImageEntity
         {
             Id = Guid.Parse("10AAC809-C188-458D-A12E-1AFC92E2FEE2"),
             Url = "http://google.com/myimage2.png",
             Caption = "This is my second image",
             TripId = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F")
         },
-        new TripImage
+        new TripImageEntity
         {
             Id = Guid.Parse("9AD58C86-AF81-4B97-BEA5-0218E5DC9E9B"),
             Url = "http://google.com/myimage3.png",
@@ -36,29 +36,35 @@ internal static class ImageHandlers
         }
     ];
 
-    public static async Task<List<TripImage>?> GetImages(string id, ITripsImageService tripsImageService)
+    public static async Task<List<TripImage>?> GetImages(string id, IMapper mapper, ITripsImageService tripsImageService)
     {
-        return await tripsImageService.GetTripImages(id);
+        var tripImageEntities = await tripsImageService.GetTripImages(id);
+        var tripImages = mapper.Map<List<TripImage>>(tripImageEntities);
+        return tripImages;
         // var result = _tripImages.Where(x => x.TripId == Guid.Parse(id)).ToList();
         // return result;
     }
 
-    public static async Task<TripImage?> GetImage(string tripId, string id, ITripsImageService tripsImageService)
+    public static async Task<TripImage?> GetImage(string tripId, string id, IMapper mapper, ITripsImageService tripsImageService)
     {
+        var tripImageEntity = await tripsImageService.GetTripImage(tripId, id);
+        var tripImage = mapper.Map<TripImage>(tripImageEntity);
         // return  _tripImages.FirstOrDefault(x => x.TripId == Guid.Parse(tripId) && x.Id == Guid.Parse(id));
-        return await tripsImageService.GetTripImage(tripId, id);
+        return tripImage;
     }
     
-    public static async Task<Created<TripImage>> PostImage(string tripId, CreateTripImageDto tripImageDto, IMapper mapper, ITripsImageService tripsImageService)
+    public static async Task<Created<TripImage>> PostImage(string tripId, TripImageCreated tripImageDto, IMapper mapper, ITripsImageService tripsImageService)
     {
-        var tripImage = mapper.Map<TripImage>(tripImageDto);  
-        tripImage.TripId = Guid.Parse(tripId);
-        await tripsImageService.CreateTripImage(tripImage);
+        var tripImageEntity = mapper.Map<TripImageEntity>(tripImageDto);  
+        tripImageEntity.TripId = Guid.Parse(tripId);
+        await tripsImageService.CreateTripImage(tripImageEntity);
+        var tripImage = mapper.Map<TripImage>(tripImageEntity);
+        
         return TypedResults.Created($"api/trips/{tripId}/images/{tripImage.Id}", tripImage);
         // _tripImages.Add(tripImage);
         // return TypedResults.Created("", tripImage);
     }
-    public static async Task<IResult> PatchImage(string tripId, string id, PatchTripImageDto tripImageDto, IMapper mapper, ITripsImageService tripsImageService)
+    public static async Task<IResult> PatchImage(string tripId, string id, TripImageUpdated tripImageDto, IMapper mapper, ITripsImageService tripsImageService)
     {
         var existingTripImage = await tripsImageService.GetTripImage(tripId, id);
         if (existingTripImage == null)
@@ -82,7 +88,7 @@ internal static class ImageHandlers
         // }
     }
     
-    public static async Task<IResult> UploadImages([FromForm] IFormFileCollection files, string tripId, IUploadTripImageUseCase uploadTripImageUseCase)
+    public static async Task<IResult> UploadImages([FromForm] IFormFileCollection files, string tripId, IMapper mapper, IUploadTripImageUseCase uploadTripImageUseCase)
     {
         if (files == null || files.Count == 0)
             return Results.BadRequest("No file uploaded.");
@@ -91,17 +97,17 @@ internal static class ImageHandlers
 
         foreach (var file in files)
         {
-            var fileDto = new TripImageUploadDto
+            var fileDto = new TripImageUpload
             {
                 FileName = file.FileName,
                 ContentType = file.ContentType,
                 Content = await GetBytesAsync(file)
             };
             var result = await uploadTripImageUseCase.UploadTripImageAsync(tripId, fileDto);
-            if (result.TripImage != null)
-            {
-                uploadedImages.Add(result.TripImage);
-            }
+
+            var trip = mapper.Map<TripImage>(result.TripImage);
+            uploadedImages.Add(trip);
+
         }
         return TypedResults.Created("", uploadedImages);
         

--- a/Travel.Api/Endpoints/ImageHandlers.cs
+++ b/Travel.Api/Endpoints/ImageHandlers.cs
@@ -6,50 +6,21 @@ using Travel.Application.Interfaces;
 using Travel.Domain.Entities;
 using Travel.Model.TripImage;
 
-
 namespace Travel.Api.Endpoints;
 
 internal static class ImageHandlers
 {
-    private static List<TripImageEntity> _tripImages =
-    [
-        new TripImageEntity
-        {
-            Id = Guid.Parse("10AAC809-C188-458D-A12E-1AFC92E2FEE3"),
-            Url = "http://google.com/myimage.png",
-            Caption = "This is my image",
-            TripId = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F")
-        },
-        new TripImageEntity
-        {
-            Id = Guid.Parse("10AAC809-C188-458D-A12E-1AFC92E2FEE2"),
-            Url = "http://google.com/myimage2.png",
-            Caption = "This is my second image",
-            TripId = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F")
-        },
-        new TripImageEntity
-        {
-            Id = Guid.Parse("9AD58C86-AF81-4B97-BEA5-0218E5DC9E9B"),
-            Url = "http://google.com/myimage3.png",
-            Caption = "This is my third image",
-            TripId = Guid.Parse("2358D025-1796-4A99-B527-D59120930E25")
-        }
-    ];
-
     public static async Task<List<TripImage>?> GetImages(string id, IMapper mapper, ITripsImageService tripsImageService)
     {
         var tripImageEntities = await tripsImageService.GetTripImages(id);
         var tripImages = mapper.Map<List<TripImage>>(tripImageEntities);
         return tripImages;
-        // var result = _tripImages.Where(x => x.TripId == Guid.Parse(id)).ToList();
-        // return result;
     }
 
     public static async Task<TripImage?> GetImage(string tripId, string id, IMapper mapper, ITripsImageService tripsImageService)
     {
         var tripImageEntity = await tripsImageService.GetTripImage(tripId, id);
         var tripImage = mapper.Map<TripImage>(tripImageEntity);
-        // return  _tripImages.FirstOrDefault(x => x.TripId == Guid.Parse(tripId) && x.Id == Guid.Parse(id));
         return tripImage;
     }
     
@@ -61,8 +32,6 @@ internal static class ImageHandlers
         var tripImage = mapper.Map<TripImage>(tripImageEntity);
         
         return TypedResults.Created($"api/trips/{tripId}/images/{tripImage.Id}", tripImage);
-        // _tripImages.Add(tripImage);
-        // return TypedResults.Created("", tripImage);
     }
     public static async Task<IResult> PatchImage(string tripId, string id, TripImageUpdated tripImageDto, IMapper mapper, ITripsImageService tripsImageService)
     {
@@ -73,19 +42,11 @@ internal static class ImageHandlers
         mapper.Map(tripImageDto, existingTripImage); 
         await tripsImageService.UpdateTripImage(existingTripImage);
         return Results.NoContent();
-        // DeleteTripImage(tripId, id);
-        // _tripImages.Add(tripImage);
-        // return TypedResults.Created("",tripImage);
     }
     
     public static async Task DeleteTripImage(string tripId, string id, ITripsImageService tripImageService)
     {
         await tripImageService.DeleteTripImageAsync(id);
-        // var image = GetImage(tripId, id);
-        // if (image != null)
-        // {
-        //     _tripImages.Remove(image);
-        // }
     }
     
     public static async Task<IResult> UploadImages([FromForm] IFormFileCollection files, string tripId, IMapper mapper, IUploadTripImageUseCase uploadTripImageUseCase)

--- a/Travel.Application/Interfaces/IMinioRepository.cs
+++ b/Travel.Application/Interfaces/IMinioRepository.cs
@@ -1,6 +1,6 @@
 using Minio.DataModel.Response;
 using Minio.DataModel.Result;
-using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Application.Interfaces;
 
@@ -9,7 +9,7 @@ public interface IMinioRepository
     public Task MakeBucketAsync(string bucketName);
     public Task<bool> BucketExistsAsync(string bucketName);
     public Task<PutObjectResponse> PutObjectStreamAsync(string bucketName, string objectName, Stream stream,
-        TripImageUploadDto fileDto);
+        TripImageUpload file);
     public Task<PutObjectResponse> PutObjectLocalAsync(string bucketName, string objectName, string filePath,
         string contentType = "image/jpeg");
     public Task<ListAllMyBucketsResult> ListBucketsAsync();

--- a/Travel.Application/Interfaces/IMinioService.cs
+++ b/Travel.Application/Interfaces/IMinioService.cs
@@ -1,6 +1,6 @@
 using Minio.DataModel.Response;
 using Minio.DataModel.Result;
-using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Application.Interfaces;
 
@@ -9,7 +9,7 @@ public interface IMinioService
     public Task MakeBucketAsync(string bucketName);
     public Task<bool> BucketExistsAsync(string bucketName);
     public Task<PutObjectResponse> PutObjectStreamAsync(string bucketName, string objectName, Stream stream,
-        TripImageUploadDto fileDto);
+        TripImageUpload file);
     public Task<PutObjectResponse> PutObjectLocalAsync(string bucketName, string objectName, string filePath,
         string contentType = "image/jpeg");
     public Task<ListAllMyBucketsResult> ListBucketsAsync();

--- a/Travel.Application/Interfaces/ITripsImageRepository.cs
+++ b/Travel.Application/Interfaces/ITripsImageRepository.cs
@@ -1,14 +1,14 @@
-using Travel.Model;
+using Travel.Domain.Entities;
 
 namespace Travel.Application.Interfaces;
 
 public interface ITripsImageRepository
 {
-    public Task<List<TripImage>?> GetTripImages(string id);
-    public Task<TripImage?> GetTripImage(string tripId, string id);
-    public Task CreateTripImage(TripImage tripImage);
+    public Task<List<TripImageEntity>?> GetTripImages(string id);
+    public Task<TripImageEntity?> GetTripImage(string tripId, string id);
+    public Task CreateTripImage(TripImageEntity tripImage);
     public Task DeleteTripImageAsync(string id);
     public Task DeleteTripImageAsync(Guid id);
-    public Task UpdateTripImage(TripImage trip);
+    public Task UpdateTripImage(TripImageEntity trip);
 
 }

--- a/Travel.Application/Interfaces/ITripsImageService.cs
+++ b/Travel.Application/Interfaces/ITripsImageService.cs
@@ -1,13 +1,13 @@
-using Travel.Model;
+using Travel.Domain.Entities;
 
 namespace Travel.Application.Interfaces;
 
 public interface ITripsImageService
 {
-    public Task<List<TripImage>?> GetTripImages(string id);
-    public Task<TripImage?> GetTripImage(string tripId, string id);
-    public Task CreateTripImage(TripImage tripImage);
+    public Task<List<TripImageEntity>?> GetTripImages(string id);
+    public Task<TripImageEntity?> GetTripImage(string tripId, string id);
+    public Task CreateTripImage(TripImageEntity tripImage);
     public Task DeleteTripImageAsync(string id);
     public Task DeleteTripImagesAsync(string id);
-    public Task UpdateTripImage(TripImage trip);
+    public Task UpdateTripImage(TripImageEntity trip);
 }

--- a/Travel.Application/Interfaces/ITripsRepository.cs
+++ b/Travel.Application/Interfaces/ITripsRepository.cs
@@ -1,12 +1,12 @@
-using Travel.Model;
+using Travel.Domain.Entities;
 
 namespace Travel.Application.Interfaces;
 
 public interface ITripsRepository
 {
-    public Task<Trip?> GetTrip(string id);
-    public List<Trip> GetTrips();
+    public Task<TripEntity?> GetTrip(string id);
+    public List<TripEntity> GetTrips();
     public Task DeleteTripAsync(string id);
-    public Task UpdateTrip(Trip trip);
-    public Task CreateTrip(Trip trip);
+    public Task UpdateTrip(TripEntity trip);
+    public Task CreateTrip(TripEntity trip);
 }

--- a/Travel.Application/Interfaces/ITripsService.cs
+++ b/Travel.Application/Interfaces/ITripsService.cs
@@ -1,14 +1,14 @@
-using Travel.Model;
+using Travel.Domain.Entities;
 
 namespace Travel.Application.Interfaces;
 
 public interface ITripsService
 {
-    public Task<Trip?> GetTrip(string id);
-    public List<Trip> GetTrips();
+    public Task<TripEntity?> GetTrip(string id);
+    public List<TripEntity> GetTrips();
 
     public Task DeleteTripAsync(string id);
-    public Task UpdateTrip(Trip trip);
-    public Task CreateTrip(Trip trip);
+    public Task UpdateTrip(TripEntity trip);
+    public Task CreateTrip(TripEntity trip);
 
 }

--- a/Travel.Application/Interfaces/IUploadTripImageUseCase.cs
+++ b/Travel.Application/Interfaces/IUploadTripImageUseCase.cs
@@ -1,8 +1,9 @@
-using Travel.Model;
+using Travel.Domain.Entities;
+using Travel.Model.TripImage;
 
 namespace Travel.Application.Interfaces;
 
 public interface IUploadTripImageUseCase
 {
-    public Task<(string Location, TripImage TripImage)> UploadTripImageAsync(string tripId, TripImageUploadDto fileDto);
+    public Task<(string Location, TripImageEntity TripImage)> UploadTripImageAsync(string tripId, TripImageUpload file);
 }

--- a/Travel.Application/Services/MinioService.cs
+++ b/Travel.Application/Services/MinioService.cs
@@ -1,7 +1,7 @@
 using Minio.DataModel.Response;
 using Minio.DataModel.Result;
 using Travel.Application.Interfaces;
-using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Application.Services;
 
@@ -28,9 +28,9 @@ public class MinioService(IMinioRepository minioRepository) : IMinioService
         return await _minioRepository.PutObjectLocalAsync(bucketName, objectName, filePath, contentType);
     }
     
-    public async Task<PutObjectResponse> PutObjectStreamAsync(string bucketName, string objectName, Stream stream, TripImageUploadDto fileDto)
+    public async Task<PutObjectResponse> PutObjectStreamAsync(string bucketName, string objectName, Stream stream, TripImageUpload file)
     {
-        return await _minioRepository.PutObjectStreamAsync(bucketName, objectName, stream, fileDto);
+        return await _minioRepository.PutObjectStreamAsync(bucketName, objectName, stream, file);
     }
 
     public async Task<ListAllMyBucketsResult> ListBucketsAsync()

--- a/Travel.Application/Services/TripsImageService.cs
+++ b/Travel.Application/Services/TripsImageService.cs
@@ -1,4 +1,5 @@
 using Travel.Application.Interfaces;
+using Travel.Domain.Entities;
 using Travel.Model;
 
 namespace Travel.Application.Services;
@@ -7,17 +8,17 @@ public class TripsImageService(ITripsImageRepository tripsImageRepository) : ITr
 {
     ITripsImageRepository _tripsImageRepository = tripsImageRepository;
 
-    public async Task<List<TripImage>?> GetTripImages(string id)
+    public async Task<List<TripImageEntity>?> GetTripImages(string id)
     {
        return await _tripsImageRepository.GetTripImages(id);
     }
 
-    public async Task<TripImage?> GetTripImage(string tripId, string id)
+    public async Task<TripImageEntity?> GetTripImage(string tripId, string id)
     {
         return await _tripsImageRepository.GetTripImage(tripId, id);
     }
 
-    public async Task CreateTripImage(TripImage tripImage)
+    public async Task CreateTripImage(TripImageEntity tripImage)
     {
         await _tripsImageRepository.CreateTripImage(tripImage);
     }
@@ -38,7 +39,7 @@ public class TripsImageService(ITripsImageRepository tripsImageRepository) : ITr
             }
         }
     }
-    public async Task UpdateTripImage(TripImage tripImage)
+    public async Task UpdateTripImage(TripImageEntity tripImage)
     {
         await _tripsImageRepository.UpdateTripImage(tripImage);
     }

--- a/Travel.Application/Services/TripsService.cs
+++ b/Travel.Application/Services/TripsService.cs
@@ -1,21 +1,22 @@
 using Travel.Application.Interfaces;
+using Travel.Domain.Entities;
 using Travel.Model;
 
 namespace Travel.Application.Services;
 
 public class TripsService(ITripsRepository tripsRepository) : ITripsService
 {
-    public async Task<Trip?> GetTrip(string id)
+    public async Task<TripEntity?> GetTrip(string id)
     {
         return await tripsRepository.GetTrip(id);
     }
 
-    public List<Trip> GetTrips()
+    public List<TripEntity> GetTrips()
     {
         return tripsRepository.GetTrips();
     }
 
-    public async Task CreateTrip(Trip trip)
+    public async Task CreateTrip(TripEntity trip)
     {
         //TODO: change startdate and enddate to DateTimeOffset type
         trip.StartDate = DateTime.SpecifyKind(trip.StartDate, DateTimeKind.Utc);
@@ -27,7 +28,7 @@ public class TripsService(ITripsRepository tripsRepository) : ITripsService
         await tripsRepository.DeleteTripAsync(id);
     }
 
-    public async Task UpdateTrip(Trip trip)
+    public async Task UpdateTrip(TripEntity trip)
     {
         //TODO: change startdate and enddate to DateTimeOffset type
         trip.StartDate = DateTime.SpecifyKind(trip.StartDate, DateTimeKind.Utc);

--- a/Travel.Application/Travel.Application.csproj
+++ b/Travel.Application/Travel.Application.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\Travel.Domain\Travel.Domain.csproj" />
       <ProjectReference Include="..\Travel.Model\Travel.Model.csproj" />
     </ItemGroup>
 

--- a/Travel.Application/UseCases/UploadTripImageUseCase.cs
+++ b/Travel.Application/UseCases/UploadTripImageUseCase.cs
@@ -1,6 +1,8 @@
 using AutoMapper;
 using Travel.Application.Interfaces;
+using Travel.Domain.Entities;
 using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Application.UseCases;
 
@@ -13,11 +15,11 @@ public class UploadTripImageUseCase(
     private readonly ITripsImageService _tripsImageService = tripsImageService;
     private readonly IMapper _mapper = mapper;
 
-    public async Task<(string Location, TripImage TripImage)> UploadTripImageAsync(string tripId, TripImageUploadDto fileDto)
+    public async Task<(string Location, TripImageEntity TripImage)> UploadTripImageAsync(string tripId, TripImageUpload file)
     {
         var tripIdLower = tripId.ToLowerInvariant();
         //TODO: add retries if minio succeeds but database fails
-        var objectName = fileDto.FileName;
+        var objectName = file.FileName;
 
         var exists = await _minioService.BucketExistsAsync(tripIdLower);
         if (!exists)
@@ -26,13 +28,13 @@ public class UploadTripImageUseCase(
             await _minioService.SetBucketPolicyToPublicAsync(tripIdLower);
         }
 
-        using var stream = new MemoryStream(fileDto.Content);
-        await _minioService.PutObjectStreamAsync(tripIdLower, objectName, stream, fileDto);
+        using var stream = new MemoryStream(file.Content);
+        await _minioService.PutObjectStreamAsync(tripIdLower, objectName, stream, file);
 
-        var tripImage = new TripImage
+        var tripImage = new TripImageEntity
         {
             TripId = Guid.Parse(tripIdLower),
-            Url = $"http://localhost:9000/{tripIdLower}/{fileDto.FileName}",
+            Url = $"http://localhost:9000/{tripIdLower}/{file.FileName}",
             Caption = ""
         };
 

--- a/Travel.Domain/Entities/TripEntity.cs
+++ b/Travel.Domain/Entities/TripEntity.cs
@@ -1,6 +1,6 @@
-namespace Travel.Model;
+namespace Travel.Domain.Entities;
 
-public class Trip
+public class TripEntity
 {
     public Guid Id { get; set; } = Guid.NewGuid();
     public string Title { get; set; }
@@ -8,5 +8,5 @@ public class Trip
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
     public string Story { get; set; } // Could be Markdown or HTML
-    public List<TripImage> Images { get; set; } = [];
+    public List<TripImageEntity> Images { get; set; } = [];
 }

--- a/Travel.Domain/Entities/TripImageEntity.cs
+++ b/Travel.Domain/Entities/TripImageEntity.cs
@@ -1,0 +1,10 @@
+namespace Travel.Domain.Entities;
+
+public class TripImageEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string Url { get; set; }
+    public string Caption { get; set; }
+    public Guid TripId { get; set; }
+    public TripEntity Trip { get; set; }   // Navigation property
+}

--- a/Travel.Infrastructure/Context/TripSeeder.cs
+++ b/Travel.Infrastructure/Context/TripSeeder.cs
@@ -1,14 +1,15 @@
 using Bogus;
 using Microsoft.EntityFrameworkCore;
+using Travel.Domain.Entities;
 using Travel.Model;
 
 namespace Travel.Infrastructure.Context;
 
 public static class TripsSeeder
 {
-    private static List<Trip> Trips = 
+    private static List<TripEntity> Trips = 
     [
-        new Trip
+        new TripEntity
         {
             Id = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F"),
             Title = "First Trip To Vegas",
@@ -17,7 +18,7 @@ public static class TripsSeeder
             EndDate = new DateTime(2025, 4, 21, 0,0,0, DateTimeKind.Utc),
             Story = "Vegas was amazing",
         },
-        new Trip
+        new TripEntity
         {
             Id = Guid.Parse("2358D025-1796-4A99-B527-D59120930E25"),
             Title = "Summer Lake",
@@ -28,23 +29,23 @@ public static class TripsSeeder
         }
     ];
 
-    private static List<TripImage> TripImages =
+    private static List<TripImageEntity> TripImages =
     [
-        new TripImage
+        new TripImageEntity
         {
             Id = Guid.Parse("10AAC809-C188-458D-A12E-1AFC92E2FEE3"),
             Url = "http://google.com/myimage.png",
             Caption = "This is my image",
             TripId = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F")
         },
-        new TripImage
+        new TripImageEntity
         {
             Id = Guid.Parse("10AAC809-C188-458D-A12E-1AFC92E2FEE2"),
             Url = "http://google.com/myimage2.png",
             Caption = "This is my second image",
             TripId = Guid.Parse("BB68B434-3026-41E1-B253-97BA308D764F")
         },
-        new TripImage
+        new TripImageEntity
         {
             Id = Guid.Parse("9AD58C86-AF81-4B97-BEA5-0218E5DC9E9B"),
             Url = "http://google.com/myimage3.png",
@@ -61,7 +62,7 @@ public static class TripsSeeder
 
     public static async Task SeedTripImageToDelete(TripsDbContext context)
     {
-        var tripImageToDelete = new TripImage
+        var tripImageToDelete = new TripImageEntity
         {
             Id = Guid.Parse("40AAC809-C188-458D-A12E-1AFC92E2FEE2"),
             Url = "http://google.com/myimage4.png",
@@ -79,13 +80,13 @@ public static class TripsSeeder
 
         var faker = new Faker("en");
 
-        var trips = new List<Trip>();
+        var trips = new List<TripEntity>();
 
         for (int i = 0; i < 5; i++)
         {
             var tripId = Guid.NewGuid();
 
-            var trip = new Trip
+            var trip = new TripEntity
             {
                 Id = tripId,
                 Title = faker.Lorem.Sentence(3),
@@ -93,12 +94,12 @@ public static class TripsSeeder
                 StartDate = faker.Date.Past(2).ToUniversalTime(),
                 EndDate = faker.Date.Recent().ToUniversalTime(),
                 Story = faker.Lorem.Paragraphs(2),
-                Images = new List<TripImage>()
+                Images = new List<TripImageEntity>()
             };
 
             for (int j = 0; j < faker.Random.Int(1, 4); j++)
             {
-                trip.Images.Add(new TripImage
+                trip.Images.Add(new TripImageEntity
                 {
                     Id = Guid.NewGuid(),
                     Url = faker.Image.PicsumUrl(),

--- a/Travel.Infrastructure/Context/TripsDbContext.cs
+++ b/Travel.Infrastructure/Context/TripsDbContext.cs
@@ -1,19 +1,20 @@
 using Microsoft.EntityFrameworkCore;
+using Travel.Domain.Entities;
 using Travel.Model;
 
 namespace Travel.Infrastructure.Context;
 
 public class TripsDbContext : DbContext
 {
-    public DbSet<Trip> Trips { get; set; }
-    public DbSet<TripImage> TripImages { get; set; }
+    public DbSet<TripEntity> Trips { get; set; }
+    public DbSet<TripImageEntity> TripImages { get; set; }
 
     public TripsDbContext(DbContextOptions<TripsDbContext> options)
         : base(options) { }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<TripImage>()
+        modelBuilder.Entity<TripImageEntity>()
             .HasOne(ti => ti.Trip)
             .WithMany(t => t.Images)
             .HasForeignKey(ti => ti.TripId)

--- a/Travel.Infrastructure/Repositories/MinioRepository.cs
+++ b/Travel.Infrastructure/Repositories/MinioRepository.cs
@@ -3,7 +3,7 @@ using Minio.DataModel.Args;
 using Minio.DataModel.Response;
 using Minio.DataModel.Result;
 using Travel.Application.Interfaces;
-using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Infrastructure.Repositories;
 
@@ -46,14 +46,14 @@ public class MinioRepository(IMinioClient minioClient) : IMinioRepository
     }
 
     public async Task<PutObjectResponse> PutObjectStreamAsync(string bucketName, string objectName, Stream stream,
-        TripImageUploadDto fileDto)
+        TripImageUpload file)
     {
         return await PutObject(new PutObjectArgs()
             .WithBucket(bucketName)
             .WithObject(objectName)
             .WithStreamData(stream)
-            .WithObjectSize(fileDto.Content.Length)
-            .WithContentType(fileDto.ContentType));
+            .WithObjectSize(file.Content.Length)
+            .WithContentType(file.ContentType));
     }
 
     public async Task<PutObjectResponse> PutObjectLocalAsync(string bucketName, string objectName, string filePath,

--- a/Travel.Infrastructure/Repositories/TripsImageRepository.cs
+++ b/Travel.Infrastructure/Repositories/TripsImageRepository.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Travel.Application.Interfaces;
+using Travel.Domain.Entities;
 using Travel.Infrastructure.Context;
-using Travel.Model;
 
 namespace Travel.Infrastructure.Repositories;
 
@@ -9,7 +9,7 @@ public class TripsImageRepository(TripsDbContext context) : ITripsImageRepositor
 {
     TripsDbContext _context = context;
     
-    public async Task<List<TripImage>?> GetTripImages(string id)
+    public async Task<List<TripImageEntity>?> GetTripImages(string id)
     {
         var images = _context.TripImages.Where(x => x.TripId == Guid.Parse(id));
 
@@ -21,7 +21,7 @@ public class TripsImageRepository(TripsDbContext context) : ITripsImageRepositor
         return null;
     }
     
-    public async Task<TripImage?> GetTripImage(string tripId, string id)
+    public async Task<TripImageEntity?> GetTripImage(string tripId, string id)
     {
         var image = _context.TripImages.Where(x => x.TripId == Guid.Parse(tripId) && x.Id == Guid.Parse(id));
         if (image.Any())
@@ -32,7 +32,7 @@ public class TripsImageRepository(TripsDbContext context) : ITripsImageRepositor
         return null;
     }
 
-    public async Task CreateTripImage(TripImage tripImage)
+    public async Task CreateTripImage(TripImageEntity tripImage)
     {
         var tripExists = await _context.Trips.AnyAsync(t => t.Id == tripImage.TripId);
         if (!tripExists)
@@ -58,7 +58,7 @@ public class TripsImageRepository(TripsDbContext context) : ITripsImageRepositor
         await DeleteTripImageAsync(tripImageId);
     }
     
-    public async Task UpdateTripImage(TripImage tripImage)
+    public async Task UpdateTripImage(TripImageEntity tripImage)
     {
         _context.TripImages.Update(tripImage);
         await _context.SaveChangesAsync();

--- a/Travel.Infrastructure/Repositories/TripsRepository.cs
+++ b/Travel.Infrastructure/Repositories/TripsRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Travel.Application.Interfaces;
+using Travel.Domain.Entities;
 using Travel.Infrastructure.Context;
 using Travel.Model;
 
@@ -13,14 +14,14 @@ public class TripsRepository : ITripsRepository
         _context = context;
     }
 
-    public async Task<Trip?> GetTrip(string id)
+    public async Task<TripEntity?> GetTrip(string id)
     {
         var tripId = Guid.Parse(id);
         
         return await _context.Trips.Include(t => t.Images).FirstOrDefaultAsync(t => t.Id == tripId);
     }
     
-    public List<Trip>  GetTrips()
+    public List<TripEntity>  GetTrips()
     {
         return _context.Trips.ToList();
     }
@@ -37,12 +38,12 @@ public class TripsRepository : ITripsRepository
         await _context.SaveChangesAsync();
     }
 
-    public async Task CreateTrip(Trip trip)
+    public async Task CreateTrip(TripEntity trip)
     { 
         await _context.Trips.AddAsync(trip);
         await _context.SaveChangesAsync();
     }
-    public async Task UpdateTrip(Trip trip)
+    public async Task UpdateTrip(TripEntity trip)
     {
         _context.Trips.Update(trip);
         await _context.SaveChangesAsync();    

--- a/Travel.Infrastructure/Travel.Infrastructure.csproj
+++ b/Travel.Infrastructure/Travel.Infrastructure.csproj
@@ -21,7 +21,6 @@
     <ItemGroup>
       <ProjectReference Include="..\Travel.Application\Travel.Application.csproj" />
       <ProjectReference Include="..\Travel.Domain\Travel.Domain.csproj" />
-      <ProjectReference Include="..\Travel.Model\Travel.Model.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Travel.Model/Trip/Trip.cs
+++ b/Travel.Model/Trip/Trip.cs
@@ -1,0 +1,12 @@
+namespace Travel.Model.Trip;
+
+public class Trip
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; }
+    public string Location { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public string Story { get; set; }
+    public List<TripImage.TripImage> Images { get; set; }
+}

--- a/Travel.Model/Trip/TripCreated.cs
+++ b/Travel.Model/Trip/TripCreated.cs
@@ -1,6 +1,6 @@
-namespace Travel.Api.DTOs;
+namespace Travel.Model.Trip;
 
-public class CreateTripDto
+public class TripCreated
 {
     public string Title { get; set; }
     public string Location { get; set; }

--- a/Travel.Model/Trip/TripUpdated.cs
+++ b/Travel.Model/Trip/TripUpdated.cs
@@ -1,12 +1,10 @@
-using Travel.Model;
+namespace Travel.Model.Trip;
 
-namespace Travel.Api.DTOs;
-
-public class PatchTripDto
+public class TripUpdated
 {
     public string? Title { get; set; }
     public string? Location { get; set; }
     public DateTime? StartDate { get; set; }
     public DateTime? EndDate { get; set; }
-    public string? Story { get; set; } // Could be Markdown or HTML
+    public string? Story { get; set; }
 }

--- a/Travel.Model/TripImage/TripImage.cs
+++ b/Travel.Model/TripImage/TripImage.cs
@@ -1,7 +1,4 @@
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.Json.Serialization;
-
-namespace Travel.Model;
+namespace Travel.Model.TripImage;
 
 public class TripImage
 {
@@ -9,5 +6,5 @@ public class TripImage
     public string Url { get; set; }
     public string Caption { get; set; }
     public Guid TripId { get; set; }
-    public Trip Trip { get; set; }   // Navigation property
+    public Trip.Trip Trip { get; set; }   // Navigation property
 }

--- a/Travel.Model/TripImage/TripImageCreated.cs
+++ b/Travel.Model/TripImage/TripImageCreated.cs
@@ -1,6 +1,6 @@
-namespace Travel.Api.DTOs;
+namespace Travel.Model.TripImage;
 
-public class CreateTripImageDto
+public class TripImageCreated
 {
     public string Url { get; set; }
     public string Caption { get; set; }

--- a/Travel.Model/TripImage/TripImageUpdated.cs
+++ b/Travel.Model/TripImage/TripImageUpdated.cs
@@ -1,8 +1,6 @@
-using Travel.Model;
+namespace Travel.Model.TripImage;
 
-namespace Travel.Api.DTOs;
-
-public class PatchTripImageDto
+public class TripImageUpdated
 {
     public string? Url { get; set; }
     public string? Caption { get; set; }

--- a/Travel.Model/TripImage/TripImageUpload.cs
+++ b/Travel.Model/TripImage/TripImageUpload.cs
@@ -1,6 +1,6 @@
-namespace Travel.Model
+namespace Travel.Model.TripImage
 {
-    public class TripImageUploadDto
+    public class TripImageUpload
     {
         public string FileName { get; set; } = string.Empty;
         public string ContentType { get; set; } = string.Empty;

--- a/Travel.Test/IntegrationTests/ImageHandlersTests.cs
+++ b/Travel.Test/IntegrationTests/ImageHandlersTests.cs
@@ -1,8 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using System.Text;
-using Travel.Api.DTOs;
-using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Test.IntegrationTests;
 
@@ -53,7 +51,7 @@ public class ImageHandlersTests : TestBase
     public async Task PostImage_ShouldCreateImage_WhenValidDataProvided()
     {
         var tripId = "BB68B434-3026-41E1-B253-97BA308D764F";
-        var newImage = new CreateTripImageDto
+        var newImage = new TripImageCreated()
         {
             Url = "http://example.com/newimage.png",
             Caption = "New Image Caption"
@@ -84,7 +82,7 @@ public class ImageHandlersTests : TestBase
         var tripId = "2358D025-1796-4A99-B527-D59120930E25";
         var imageId = "9AD58C86-AF81-4B97-BEA5-0218E5DC9E9B";
         
-        var updatedImage = new PatchTripImageDto
+        var updatedImage = new TripImageUpdated()
         {
             Caption = "Updated Image Caption"
         };

--- a/Travel.Test/IntegrationTests/TripHandlersTests.cs
+++ b/Travel.Test/IntegrationTests/TripHandlersTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
-using Travel.Api.DTOs;
-using Travel.Model;
+using Travel.Model.Trip;
 
 namespace Travel.Test.IntegrationTests;
 
@@ -31,7 +30,7 @@ public class TripHandlersTests : TestBase
     [TestMethod]
     public async Task PostTrip_Should_CreateTrip()
     {
-        CreateTripDto createTripDto = new CreateTripDto
+        TripCreated createTripDto = new TripCreated
         {
             Title = "Test Trip",
             Location = "Test Location",
@@ -58,7 +57,7 @@ public class TripHandlersTests : TestBase
     [TestMethod]
     public async Task PatchTrip_Should_Return404_WhenInvalidTripId()
     {
-        PatchTripDto patchTrip = new PatchTripDto
+        TripUpdated patchTrip = new TripUpdated
         {
             Title = "Test Trip",
         }; 
@@ -72,7 +71,7 @@ public class TripHandlersTests : TestBase
     [TestMethod]
     public async Task PatchTrip_Should_UpdateTripWhenValid()
     {
-        PatchTripDto patchTrip = new PatchTripDto
+        TripUpdated patchTrip = new TripUpdated
         {
             Title = "Updated Trip",
             Story = "Updated story"
@@ -100,7 +99,7 @@ public class TripHandlersTests : TestBase
         Assert.IsNull(content, "Expected empty content for deleted trip");
     }
     
-    private static void AssertTripsAreEqual(Trip trip, CreateTripDto createTripDto)
+    private static void AssertTripsAreEqual(Trip trip, TripCreated createTripDto)
     {
         Assert.AreEqual(createTripDto.Title, trip?.Title);
         Assert.AreEqual(createTripDto.Location, trip?.Location);
@@ -109,7 +108,7 @@ public class TripHandlersTests : TestBase
         Assert.AreEqual(createTripDto.Story, trip?.Story);
     }
 
-    private static void AssertTripsAreEqual(Trip trip, PatchTripDto patchTripDto)
+    private static void AssertTripsAreEqual(Trip trip, TripUpdated patchTripDto)
     {
         if (patchTripDto.Title != null)
             Assert.AreEqual(patchTripDto.Title, trip?.Title);

--- a/Travel.Test/UnitTests/Application/MinioServiceTests.cs
+++ b/Travel.Test/UnitTests/Application/MinioServiceTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Travel.Application.Interfaces;
 using Travel.Application.Services;
 using Travel.Model;
+using Travel.Model.TripImage;
 
 namespace Travel.Test.UnitTests.Application;
 
@@ -59,7 +60,7 @@ public class MinioServiceTests
     public async Task PutObjectStreamAsync_ReturnsRepositoryResult()
     {
         var response = new PutObjectResponse(HttpStatusCode.Accepted, "key", new Dictionary<string,string>(), 0, "contentMd5");
-        var mockFile = new Mock<TripImageUploadDto>();
+        var mockFile = new Mock<TripImageUpload>();
         var stream = new MemoryStream();
         _mockRepo.Setup(r => r.PutObjectStreamAsync("bucket", "object", stream, mockFile.Object)).ReturnsAsync(response);
         var result = await _service.PutObjectStreamAsync("bucket", "object", stream, mockFile.Object);

--- a/Travel.Test/UnitTests/Application/TripsImageServiceTests.cs
+++ b/Travel.Test/UnitTests/Application/TripsImageServiceTests.cs
@@ -1,8 +1,10 @@
 using Moq;
 using Travel.Application.Interfaces;
 using Travel.Application.Services;
+using Travel.Domain.Entities;
 using Travel.Model;
 using Guid = Travel.Domain.Extensions.Guid;
+
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
 namespace Travel.Test.UnitTests.Application;
@@ -24,7 +26,7 @@ public class TripsImageServiceTests
     public async Task GetTripImages_ReturnsImages()
     {
         var tripId = Guid.NewGuidAsString();
-        var images = new List<TripImage> { new TripImage { Id = Guid.NewGuid() }, new TripImage { Id = Guid.NewGuid() } };
+        var images = new List<TripImageEntity> { new TripImageEntity { Id = Guid.NewGuid() }, new TripImageEntity { Id = Guid.NewGuid() } };
         _mockRepo.Setup(r => r.GetTripImages(tripId)).ReturnsAsync(images);
         var result = await _service.GetTripImages(tripId);
         CollectionAssert.AreEqual(images, result);
@@ -33,7 +35,7 @@ public class TripsImageServiceTests
     [TestMethod]
     public async Task GetTripImage_ReturnsImage()
     {
-        var image = new TripImage { Id = Guid.NewGuid() };
+        var image = new TripImageEntity { Id = Guid.NewGuid() };
         var tripId = Guid.NewGuidAsString();
         var imageId = image.Id.ToString();
         _mockRepo.Setup(r => r.GetTripImage(tripId, imageId)).ReturnsAsync(image);
@@ -44,7 +46,7 @@ public class TripsImageServiceTests
     [TestMethod]
     public async Task CreateTripImage_CallsRepository()
     {
-        var image = new TripImage { Id = Guid.NewGuid() };
+        var image = new TripImageEntity { Id = Guid.NewGuid() };
         _mockRepo.Setup(r => r.CreateTripImage(image)).Returns(Task.CompletedTask);
         await _service.CreateTripImage(image);
         _mockRepo.Verify(r => r.CreateTripImage(image), Times.Once);
@@ -63,7 +65,7 @@ public class TripsImageServiceTests
     public async Task DeleteTripImages_DeletesAllImages()
     {
         var tripId = Guid.NewGuidAsString();
-        var images = new List<TripImage> { new TripImage { Id = Guid.NewGuid() }, new TripImage { Id = Guid.NewGuid() } };
+        var images = new List<TripImageEntity> { new TripImageEntity { Id = Guid.NewGuid() }, new TripImageEntity { Id = Guid.NewGuid() } };
         _mockRepo.Setup(r => r.GetTripImages(tripId)).ReturnsAsync(images);
         await _service.DeleteTripImagesAsync(tripId);
         _mockRepo.Verify(r => r.DeleteTripImageAsync(It.Is<string>(id => id == images[0].Id.ToString() || id == images[1].Id.ToString())), Times.Exactly(2));
@@ -72,7 +74,7 @@ public class TripsImageServiceTests
     [TestMethod]
     public async Task UpdateTripImage_CallsRepository()
     {
-        var image = new TripImage { Id = Guid.NewGuid() };
+        var image = new TripImageEntity { Id = Guid.NewGuid() };
         _mockRepo.Setup(r => r.UpdateTripImage(image)).Returns(Task.CompletedTask);
         await _service.UpdateTripImage(image);
         _mockRepo.Verify(r => r.UpdateTripImage(image), Times.Once);

--- a/Travel.Test/UnitTests/Application/TripsServiceTests.cs
+++ b/Travel.Test/UnitTests/Application/TripsServiceTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using Travel.Application.Interfaces;
 using Travel.Application.Services;
+using Travel.Domain.Entities;
 using Travel.Model;
 using Guid = Travel.Domain.Extensions.Guid;
 namespace Travel.Test.UnitTests.Application;
@@ -21,7 +22,7 @@ public class TripsServiceTests
     [TestMethod]
     public async Task GetTrip_ReturnsTrip_WhenFound()
     {
-        var trip = new Trip { Id = Guid.NewGuid(), Title = "Test Trip" };
+        var trip = new TripEntity { Id = Guid.NewGuid(), Title = "Test Trip" };
         _mockRepo.Setup(r => r.GetTrip(trip.Id.ToString())).ReturnsAsync(trip);
         var result = await _service.GetTrip(trip.Id.ToString());
         Assert.AreEqual(trip, result);
@@ -30,7 +31,7 @@ public class TripsServiceTests
     [TestMethod]
     public async Task GetTrip_ReturnsNull_WhenNotFound()
     {
-        _mockRepo.Setup(r => r.GetTrip(It.IsAny<string>())).ReturnsAsync((Trip?)null);
+        _mockRepo.Setup(r => r.GetTrip(It.IsAny<string>())).ReturnsAsync((TripEntity?)null);
         var result = await _service.GetTrip(Guid.NewGuidAsString());
         Assert.IsNull(result);
     }
@@ -38,7 +39,7 @@ public class TripsServiceTests
     [TestMethod]
     public void GetTrips_ReturnsListOfTrips()
     {
-        var trips = new List<Trip> { new Trip { Title = "Trip1" }, new Trip { Title = "Trip2" } };
+        var trips = new List<TripEntity> { new TripEntity { Title = "Trip1" }, new TripEntity { Title = "Trip2" } };
         _mockRepo.Setup(r => r.GetTrips()).Returns(trips);
         var result = _service.GetTrips();
         CollectionAssert.AreEqual(trips, result);
@@ -47,7 +48,7 @@ public class TripsServiceTests
     [TestMethod]
     public async Task CreateTrip_SetsDatesToUtc_AndCallsRepository()
     {
-        var trip = new Trip { Title = "Trip", StartDate = DateTime.Now, EndDate = DateTime.Now.AddDays(1) };
+        var trip = new TripEntity { Title = "Trip", StartDate = DateTime.Now, EndDate = DateTime.Now.AddDays(1) };
         _mockRepo.Setup(r => r.CreateTrip(trip)).Returns(Task.CompletedTask);
         await _service.CreateTrip(trip);
         Assert.AreEqual(DateTimeKind.Utc, trip.StartDate.Kind);
@@ -66,7 +67,7 @@ public class TripsServiceTests
     [TestMethod]
     public async Task UpdateTrip_CallsRepository()
     {
-        var trip = new Trip { Title = "Trip" };
+        var trip = new TripEntity { Title = "Trip" };
         _mockRepo.Setup(r => r.UpdateTrip(trip)).Returns(Task.CompletedTask);
         await _service.UpdateTrip(trip);
         _mockRepo.Verify(r => r.UpdateTrip(trip), Times.Once);

--- a/Travel.Test/UnitTests/Application/UploadTripImageUseCaseTests.cs
+++ b/Travel.Test/UnitTests/Application/UploadTripImageUseCaseTests.cs
@@ -4,7 +4,9 @@ using Minio.DataModel.Response;
 using Moq;
 using Travel.Application.Interfaces;
 using Travel.Application.UseCases;
+using Travel.Domain.Entities;
 using Travel.Model;
+using Travel.Model.TripImage;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
@@ -19,7 +21,7 @@ public class UploadTripImageUseCaseTests
     private UploadTripImageUseCase _useCase;
     private string _tripId;
     private string _fileName;
-    private TripImageUploadDto _fileDto;
+    private TripImageUpload _file;
 
     [TestInitialize]
     public void TestInitialize()
@@ -30,7 +32,7 @@ public class UploadTripImageUseCaseTests
         _useCase = new UploadTripImageUseCase(_mockMinioService.Object, _mockTripsImageService.Object, _mockMapper.Object);
         _tripId = Guid.NewGuid().ToString();
         _fileName = "test.jpg";
-        _fileDto = new TripImageUploadDto
+        _file = new TripImageUpload
         {
             FileName = _fileName,
             ContentType = "image/jpeg",
@@ -44,18 +46,18 @@ public class UploadTripImageUseCaseTests
         _mockMinioService.Setup(x => x.BucketExistsAsync(_tripId)).ReturnsAsync(false);
         _mockMinioService.Setup(x => x.MakeBucketAsync(_tripId)).Returns(Task.CompletedTask);
         _mockMinioService.Setup(x => x.SetBucketPolicyToPublicAsync(_tripId)).Returns(Task.CompletedTask);
-        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _fileDto))
+        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _file))
             .ReturnsAsync(new PutObjectResponse(HttpStatusCode.Accepted, "key", new Dictionary<string,string>(), 0, "contentMd5"));
 
         var tripImage = new TripImage { TripId = Guid.Parse(_tripId), Url = $"http://localhost:9000/{_tripId}/{_fileName}", Caption = "" };
-        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImage>())).Returns(Task.CompletedTask);
+        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImageEntity>())).Returns(Task.CompletedTask);
 
-        var (location, resultImage) = await _useCase.UploadTripImageAsync(_tripId, _fileDto);
+        var (location, resultImage) = await _useCase.UploadTripImageAsync(_tripId, _file);
 
         _mockMinioService.Verify(x => x.MakeBucketAsync(_tripId), Times.Once);
         _mockMinioService.Verify(x => x.SetBucketPolicyToPublicAsync(_tripId), Times.Once);
-        _mockMinioService.Verify(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _fileDto), Times.Once);
-        _mockTripsImageService.Verify(x => x.CreateTripImage(It.IsAny<TripImage>()), Times.Once);
+        _mockMinioService.Verify(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _file), Times.Once);
+        _mockTripsImageService.Verify(x => x.CreateTripImage(It.IsAny<TripImageEntity>()), Times.Once);
         Assert.AreEqual($"api/trips/{_tripId}/images/{resultImage.Id}", location);
         Assert.AreEqual(tripImage.TripId, resultImage.TripId);
         Assert.AreEqual(tripImage.Url, resultImage.Url);
@@ -65,16 +67,16 @@ public class UploadTripImageUseCaseTests
     public async Task UploadTripImageAsync_BucketAlreadyExists_DoesNotCreateBucket()
     {
         _mockMinioService.Setup(x => x.BucketExistsAsync(_tripId)).ReturnsAsync(true);
-        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _fileDto))
+        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _file))
             .ReturnsAsync(new PutObjectResponse(HttpStatusCode.Accepted, "key", new Dictionary<string,string>(), 0, "contentMd5"));
-        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImage>())).Returns(Task.CompletedTask);
+        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImageEntity>())).Returns(Task.CompletedTask);
 
-        var (location, resultImage) = await _useCase.UploadTripImageAsync(_tripId, _fileDto);
+        var (location, resultImage) = await _useCase.UploadTripImageAsync(_tripId, _file);
 
         _mockMinioService.Verify(x => x.MakeBucketAsync(_tripId), Times.Never);
         _mockMinioService.Verify(x => x.SetBucketPolicyToPublicAsync(_tripId), Times.Never);
-        _mockMinioService.Verify(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _fileDto), Times.Once);
-        _mockTripsImageService.Verify(x => x.CreateTripImage(It.IsAny<TripImage>()), Times.Once);
+        _mockMinioService.Verify(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _file), Times.Once);
+        _mockTripsImageService.Verify(x => x.CreateTripImage(It.IsAny<TripImageEntity>()), Times.Once);
         Assert.AreEqual($"api/trips/{_tripId}/images/{resultImage.Id}", location);
     }
 
@@ -82,24 +84,24 @@ public class UploadTripImageUseCaseTests
     public async Task UploadTripImageAsync_TripImageCreationFails_ThrowsException()
     {
         _mockMinioService.Setup(x => x.BucketExistsAsync(_tripId)).ReturnsAsync(true);
-        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _fileDto))
+        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _file))
             .ReturnsAsync(new PutObjectResponse(HttpStatusCode.Accepted, "key", new Dictionary<string,string>(), 0, "contentMd5"));
-        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImage>())).ThrowsAsync(new Exception("DB error"));
+        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImageEntity>())).ThrowsAsync(new Exception("DB error"));
 
         await Assert.ThrowsExceptionAsync<Exception>(async () =>
-            await _useCase.UploadTripImageAsync(_tripId, _fileDto));
+            await _useCase.UploadTripImageAsync(_tripId, _file));
     }
 
     [TestMethod]
     public async Task UploadTripImageAsync_MinioUploadFails_ThrowsException()
     {
         _mockMinioService.Setup(x => x.BucketExistsAsync(_tripId)).ReturnsAsync(true);
-        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _fileDto))
+        _mockMinioService.Setup(x => x.PutObjectStreamAsync(_tripId, _fileName, It.IsAny<Stream>(), _file))
             .ThrowsAsync(new Exception("Minio error"));
-        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImage>())).Returns(Task.CompletedTask);
+        _mockTripsImageService.Setup(x => x.CreateTripImage(It.IsAny<TripImageEntity>())).Returns(Task.CompletedTask);
 
         await Assert.ThrowsExceptionAsync<Exception>(async () =>
-            await _useCase.UploadTripImageAsync(_tripId, _fileDto));
+            await _useCase.UploadTripImageAsync(_tripId, _file));
     }
 
     [TestMethod]


### PR DESCRIPTION
This Pull Request primarily focuses on transitioning the codebase to use domain-specific entities (TripEntity and TripImageEntity) instead of relying on models for trips and images. This effort includes changes across API, application services, repositories, and tests to ensure the application adheres to a domain-driven design approach.

### Main Changes
**Domain Layer Addition and Refactoring:**
Moved Trip and TripImage models to a new Travel.Domain.Entities namespace as TripEntity and TripImageEntity.
Updated navigation properties and references for TripEntity and TripImageEntity.

**Service and Repository Adjustments:**
Reworked all service and repository interfaces and implementations to use the new entities instead of models.
Adjusted dependent methods and logic in services and repositories to align with the entity-driven approach.

**API Changes:**
Updated DTO mapping in TripProfile for consistency with the new domain entity structure.
Refactored API endpoints (e.g., TripHandlers and ImageHandlers) to utilize new entities and revised interfaces.

**Test Updates:**
Replaced references to models with the corresponding entities in unit and integration tests.
Adjusted mocked data and assertions to accommodate the entity-driven changes.

**Improved Mapping:**
Enhanced usage of AutoMapper to map between domain entities and DTOs where necessary.

**Project Adjustments:**
Updated project references to incorporate the new domain layer and removed now-obsolete Travel.Model references.
This is a comprehensive refactor aimed at cleaning up the separation of concerns and aligning the project's structure with domain-driven design principles.